### PR TITLE
Design Situations Development - DocStrings Update for CEN and DIN National Annex

### DIFF
--- a/RFEM/LoadCasesAndCombinations/designSituation.py
+++ b/RFEM/LoadCasesAndCombinations/designSituation.py
@@ -17,22 +17,39 @@ class DesignSituation():
             user_defined_name (bool): Enable/Disable User-Defined Name
             name (str, optional): User-Defined Name (Applicable when user_defined_name = TRUE)
             active (bool): Enable/Disable Design Situation Activity
-            design_situation_type (int): Design Situation Numeric Code
-                6122 = ULS (EQU) - Permanent and transient,
-                6993 = ULS (EQU) - Accidental - psi-1,1,
-                6994 = ULS (EQU) - Accidental - psi-2,1,
-                6995 = ULS (EQU) - Accidental - Snow - psi-1,1,
-                6996 = ULS (EQU) - Accidental - Snow - psi-2,1,
-                6997 = ULS (EQU) - Seismic,
-                7007 = ULS (STR/GEO) - Permanent and transient - Eq. 6.10,
-                7010 = ULS (STR/GEO) - Accidental - psi-1,1,
-                7011 = ULS (STR/GEO) - Accidental - psi-2,1,
-                7012 = ULS (STR/GEO) - Accidental - Snow - psi-1,1,
-                7013 = ULS (STR/GEO) - Accidental - Snow - psi-2,1,
-                7014 = ULS (STR/GEO) - Seismic,
-                6193 = SLS - Characteristic,
-                6194 = SLS - Frequent,
-                6195 = SLS - Quasi-permanent
+            design_situation_type (int): Design Situation Numeric Code (Variable key inputs, dependant on Standards defined in the model)
+
+                Applicable to Standard Group EN 1990 with National Annex CEN | 2010-04 (See Model Base Data > Standards I)
+                    6122 = ULS (EQU) - Permanent and transient,
+                    6993 = ULS (EQU) - Accidental - psi-1,1,
+                    6994 = ULS (EQU) - Accidental - psi-2,1,
+                    6997 = ULS (EQU) - Seismic,
+                    7007 = ULS (STR/GEO) - Permanent and transient - Eq. 6.10,
+                    7008 = ULS (STR/GEO) - Permanent and transient - Eq. 6.10a and 6.10b,
+                    7010 = ULS (STR/GEO) - Accidental - psi-1,1,
+                    7011 = ULS (STR/GEO) - Accidental - psi-2,1,
+                    7014 = ULS (STR/GEO) - Seismic,
+                    6193 = SLS - Characteristic,
+                    6194 = SLS - Frequent,
+                    6195 = SLS - Quasi-permanent.
+
+                Applicable to Standard Group EN 1990 with National Annex DIN | 2012-08 (See Model Base Data > Standards I)
+                    6122 = ULS (EQU) - Permanent and transient,
+                    6993 = ULS (EQU) - Accidental - psi-1,1,
+                    6994 = ULS (EQU) - Accidental - psi-2,1,
+                    6995 = ULS (EQU) - Accidental - Snow - psi-1,1,
+                    6996 = ULS (EQU) - Accidental - Snow - psi-2,1,
+                    6997 = ULS (EQU) - Seismic,
+                    7007 = ULS (STR/GEO) - Permanent and transient - Eq. 6.10,
+                    7010 = ULS (STR/GEO) - Accidental - psi-1,1,
+                    7011 = ULS (STR/GEO) - Accidental - psi-2,1,
+                    7012 = ULS (STR/GEO) - Accidental - Snow - psi-1,1,
+                    7013 = ULS (STR/GEO) - Accidental - Snow - psi-2,1,
+                    7014 = ULS (STR/GEO) - Seismic,
+                    6193 = SLS - Characteristic,
+                    6194 = SLS - Frequent,
+                    6195 = SLS - Quasi-permanent.
+                    
             comment (str, optional): Comments
             params (dict, optional): Parameters
         """

--- a/UnitTests/test_DesignSituations.py
+++ b/UnitTests/test_DesignSituations.py
@@ -29,44 +29,32 @@ def test_design_situation():
 	DesignSituation(no= 3, user_defined_name= False, design_situation_type= 6994, comment= 'ULS (EQU) - Accidental - psi-2,1')
 	ds = clientModel.service.get_design_situation(3)
 	assert ds.no == 3
-	DesignSituation(no= 4, user_defined_name= False, design_situation_type= 6995, comment= 'ULS (EQU) - Accidental - Snow - psi-1,1')
-	ds = clientModel.service.get_design_situation(4)
-	assert ds.no == 4
 
 	# Testing: Manual naming, design situation keys
-	DesignSituation(no= 5, user_defined_name= True, name= 'MANUAL NAME: ULS (EQU) - Accidental - Snow - psi-2,1', design_situation_type= 6996)
+	DesignSituation(no= 4, user_defined_name= True, name= 'MANUAL NAME: ULS (EQU) - Seismic', design_situation_type= 6997)
+	ds = clientModel.service.get_design_situation(4)
+	assert ds.no == 4
+	# Testing: Design situation keys
+	DesignSituation(5, design_situation_type= 7007)
 	ds = clientModel.service.get_design_situation(5)
 	assert ds.no == 5
-	DesignSituation(no= 6, user_defined_name= True, name= 'MANUAL NAME: ULS (EQU) - Seismic', design_situation_type= 6997)
+	DesignSituation(6, design_situation_type= 7010)
 	ds = clientModel.service.get_design_situation(6)
 	assert ds.no == 6
-	# Testing: Design situation keys
-	DesignSituation(7, design_situation_type= 7007)
+	DesignSituation(7, design_situation_type= 7011)
 	ds = clientModel.service.get_design_situation(7)
 	assert ds.no == 7
-	DesignSituation(8, design_situation_type= 7010)
+	# Testing: Active toggle and design situation keys
+	DesignSituation(8, design_situation_type= 7014, active= True)
 	ds = clientModel.service.get_design_situation(8)
 	assert ds.no == 8
-	DesignSituation(9, design_situation_type= 7011)
+	DesignSituation(9, design_situation_type= 6193, active= True)
 	ds = clientModel.service.get_design_situation(9)
 	assert ds.no == 9
-	DesignSituation(10, design_situation_type= 7012)
+	DesignSituation(10, design_situation_type= 6194, active= False)
 	ds = clientModel.service.get_design_situation(10)
 	assert ds.no == 10
-	DesignSituation(11, design_situation_type= 7013)
+	DesignSituation(11, design_situation_type= 6195, active= False)
 	ds = clientModel.service.get_design_situation(11)
 	assert ds.no == 11
-	# Testing: Active toggle and design situation keys
-	DesignSituation(12, design_situation_type= 7014, active= True)
-	ds = clientModel.service.get_design_situation(12)
-	assert ds.no == 12
-	DesignSituation(13, design_situation_type= 6193, active= True)
-	ds = clientModel.service.get_design_situation(13)
-	assert ds.no == 13
-	DesignSituation(14, design_situation_type= 6194, active= False)
-	ds = clientModel.service.get_design_situation(14)
-	assert ds.no == 14
-	DesignSituation(15, design_situation_type= 6195, active= False)
-	ds = clientModel.service.get_design_situation(15)
-	assert ds.no == 15
 	clientModel.service.finish_modification()


### PR DESCRIPTION
The Design Situation Types were originally coded exclusively for DIN National Annex. Under circumstances where the CEN remains as the National Annex, the keys for the respective design situations change. As such, the DocStrings has been updated to accomodate both CEN and DIN.

Additional regions and keys can be implemented in a similar manner.