### PR TITLE
model inheritance for node, no mutable arguments, added test to show …

### DIFF
--- a/RFEM/BasicObjects/node.py
+++ b/RFEM/BasicObjects/node.py
@@ -4,14 +4,17 @@ from RFEM.enums import NodeReferenceType
 from RFEM.initModel import Model, clearAtributes
 from math import pi
 
-class Node():
+from RFEM.rfemObject import RfemObject
+
+
+class Node(RfemObject):
     def __init__(self,
                  no: int = 1,
                  coordinate_X: float = 0.0,
                  coordinate_Y: float = 0.0,
                  coordinate_Z: float = 0.0,
                  comment: str = '',
-                 params: dict = {}):
+                 params: dict = None):
 
         '''
          Args:
@@ -22,29 +25,18 @@ class Node():
             comment (str, optional): Comments
             params (dict, optional): Parameters
         '''
-        # Client model | Node
-        clientObject = Model.clientModel.factory.create('ns0:node')
-
-        # Clears object atributes | Sets all atributes to None
-        clearAtributes(clientObject)
+        super().__init__('ns0:node', comment, params)
 
         # Node No.
-        clientObject.no = no
+        self.clientObject.no = no
 
         # Coordinates
-        clientObject.coordinate_1 = coordinate_X
-        clientObject.coordinate_2 = coordinate_Y
-        clientObject.coordinate_3 = coordinate_Z
-
-        # Comment
-        clientObject.comment = comment
-
-        # Adding optional parameters via dictionary
-        for key in params:
-            clientObject[key] = params[key]
+        self.clientObject.coordinate_1 = coordinate_X
+        self.clientObject.coordinate_2 = coordinate_Y
+        self.clientObject.coordinate_3 = coordinate_Z
 
         # Add Node to client model
-        Model.clientModel.service.set_node(clientObject)
+        Model.clientModel.service.set_node(self.clientObject)
 
     def Standard(self,
                  no: int = 1,

--- a/RFEM/rfemObject.py
+++ b/RFEM/rfemObject.py
@@ -1,0 +1,27 @@
+from RFEM.initModel import Model
+
+
+class RfemObject:
+    def __init__(self,
+                 key: str,
+                 comment: str = '',
+                 params: dict = None):
+
+        # Mutable Default Arguments
+        if params is None:
+            params = {}
+
+        # Client model | Node
+        self.clientObject = Model.clientModel.factory.create(key)
+
+        # Clears object attributes | Sets all attributes to None
+        for i in iter(self.clientObject):
+            self.clientObject[i[0]] = None
+
+        # Adding optional parameters via dictionary
+        # This happens first to prevent overwriting of other properties
+        for key in params:
+            self.clientObject[key] = params[key]
+
+        # Comment
+        self.clientObject.comment = comment

--- a/UnitTests/test_node.py
+++ b/UnitTests/test_node.py
@@ -22,7 +22,8 @@ def test_node():
     Model.clientModel.service.delete_all()
     Model.clientModel.service.begin_modification()
 
-    Node(1, 0, 0, 0)
+    Node(1, 0, 0, 0, params={"no": 5}) # try to override no
+    #Node(1, 0, 0, 0)
     Node(2, 5, 0, 0)
     Node.Standard(0, 3, [5, 5, 0],NodeCoordinateSystemType.COORDINATE_SYSTEM_CARTESIAN)
     Node.BetweenTwoNodes(0,4,2,3,NodeReferenceType.REFERENCE_TYPE_L, 1, [True, 0.60])
@@ -40,6 +41,14 @@ def test_node():
 
     node = Model.clientModel.service.get_node(1)
     assert node.type == 'TYPE_STANDARD'
+    assert node.coordinate_1 == 0.0
+    assert node.coordinate_2 == 0.0
+    assert node.coordinate_3 == 0.0
+    node = Model.clientModel.service.get_node(2)
+    assert node.type == 'TYPE_STANDARD'
+    assert node.coordinate_1 == 5.0
+    assert node.coordinate_2 == 0.0
+    assert node.coordinate_3 == 0.0
     node = Model.clientModel.service.get_node(3)
     assert node.type == 'TYPE_STANDARD'
     node = Model.clientModel.service.get_node(4)


### PR DESCRIPTION
this is a proposal to cover certain issues:

1. inheritance: as I understand (almost) all classes inside \RFEM follow the same principles, so to remove redundant code I stronlgy suggest to create a baseclass and put all of that code there. 
2. adding optional parameters is happening at the end and this is a potential pitfall because you could easily overwrite the properties definied earlier (see example in unittest)
3. never user mutable default arguments. in the whole project arguments default arguments like empty lists or dicts are used. this is very dangerous, because this has sideeffects that are very difficult to spot. (in short: _Python’s default arguments are evaluated once when the function is defined, not each time the function is called (like it is in say, Ruby). This means that if you use a mutable default argument and mutate it, you will and have mutated that object for all future calls to the function as well_.)
[https://docs.python-guide.org/writing/gotchas/#:~:text=Python's%20default%20arguments%20are%20evaluated,to%20the%20function%20as%20well.](https://docs.python-guide.org/writing/gotchas/#:~:text=Python's%20default%20arguments%20are%20evaluated,to%20the%20function%20as%20well.)