### PR TITLE
change: load_parameter allways a list

### DIFF
--- a/RFEM/Loads/memberLoad.py
+++ b/RFEM/Loads/memberLoad.py
@@ -84,11 +84,11 @@ class MemberLoad():
             members_no (str): Assigned Member(s)
             load_distribution (enum): Member Load Distribution Enumeration
             load_direction (enum): Member Load Direction Enumeration
-            load_parameter (float/list/list of lists): Load Parameter List
+            load_parameter (list/list of lists): Load Parameter List
                 for load_distribution == LOAD_DISTRIBUTION_UNIFORM:
-                    load_parameter = magnitude
+                    load_parameter = [magnitude]
                 for load_distribution == LOAD_DISTRIBUTION_UNIFORM_TOTAL:
-                    load_parameter = magnitude
+                    load_parameter = [magnitude]
                 for load_distribution == LOAD_DISTRIBUTION_CONCENTRATED_1:
                     load_parameter = [relative_distance = False, magnitude, distance_a]
                 for load_distribution == LOAD_DISTRIBUTION_CONCENTRATED_N:
@@ -148,7 +148,7 @@ class MemberLoad():
 
         #Load Magnitude and Parameters
         if load_distribution.name == "LOAD_DISTRIBUTION_UNIFORM" or load_distribution.name == "LOAD_DISTRIBUTION_UNIFORM_TOTAL":
-            clientObject.magnitude = load_parameter
+            clientObject.magnitude = load_parameter[0]
 
         elif load_distribution.name == "LOAD_DISTRIBUTION_CONCENTRATED_1":
             clientObject.distance_a_is_defined_as_relative = load_parameter[0]
@@ -384,9 +384,9 @@ class MemberLoad():
             members_no (str): Assigned Member(s)
             load_distribution (enum): Load Distribution Enumeration
             load_direction (enum): Load Direction Enumeration
-            load_parameter (float/list/list of lists): Load Parameter List
+            load_parameter (list/list of lists): Load Parameter List
                 for load_distribution == LOAD_DISTRIBUTION_UNIFORM:
-                    load_parameter = magnitude
+                    load_parameter = [magnitude]
                 for load_distribution == LOAD_DISTRIBUTION_CONCENTRATED_1:
                     load_parameter = [relative_distance = False, magnitude, distance_a]
                 for load_distribution == LOAD_DISTRIBUTION_CONCENTRATED_N:


### PR DESCRIPTION
# Description

In all cases, for all staticmethods, except on case for `MemberLoad.Force`:
```python
if load_distribution.name == "LOAD_DISTRIBUTION_UNIFORM" or load_distribution.name == "LOAD_DISTRIBUTION_UNIFORM_TOTAL":
            clientObject.magnitude = load_parameter
```

_load_parameter_ is a _float_, not a _list_.

**Is now**

Right now for **analogical** case for Force and Moment user need to use float and list:

```python
MemberLoad.Force(1, 1, "1", MemberLoadDistribution.LOAD_DISTRIBUTION_UNIFORM, MemberLoadDirection.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE, 1000.0)
MemberLoad.Moment(2, 1, "1", MemberLoadDistribution.LOAD_DISTRIBUTION_UNIFORM, MemberLoadDirection.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE, [1000.0])
```
+

There is a mix between type hints, doc strings and code

**After changes**

In all cases User uses _list_

```python
MemberLoad.Force(1, 1, "1", MemberLoadDistribution.LOAD_DISTRIBUTION_UNIFORM, MemberLoadDirection.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE, [1000.0])
MemberLoad.Moment(2, 1, "1", MemberLoadDistribution.LOAD_DISTRIBUTION_UNIFORM, MemberLoadDirection.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE, [1000.0])
```

Additionally there is no more mix between type hints, doc strings, code. List is everywhere


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
