### PR TITLE
change: MemberHinge comments for units for passed values

### DIFF
--- a/RFEM/TypesForMembers/memberHinge.py
+++ b/RFEM/TypesForMembers/memberHinge.py
@@ -59,22 +59,22 @@ class MemberHinge():
         # Coordinate System
         clientObject.coordinate_system = coordinate_system
 
-        # Translational Release/Spring [kN/m] N
+        # Translational Release/Spring [N/m] N
         clientObject.axial_release_n = translational_release_n
 
-        # Translational Release/Spring [kN/m] Vy
+        # Translational Release/Spring [N/m] Vy
         clientObject.axial_release_vy = translational_release_vy
 
-        # Translational Release/Spring [kN/m] Vz
+        # Translational Release/Spring [N/m] Vz
         clientObject.axial_release_vz = translational_release_vz
 
-        # Rotational Release/Spring [kNm/rad] Mt
+        # Rotational Release/Spring [Nm/rad] Mt
         clientObject.moment_release_mt = rotational_release_mt
 
-        # Rotational Release/Spring [kNm/rad] My
+        # Rotational Release/Spring [Nm/rad] My
         clientObject.moment_release_my = rotational_release_my
 
-        # Rotational Release/Spring [kNm/rad] Mz
+        # Rotational Release/Spring [Nm/rad] Mz
         clientObject.moment_release_mz = rotational_release_mz
 
         # Translational Release N Nonlinearity


### PR DESCRIPTION
# Description

Bellows code 

``` python
# MemberHinges
MemberHinge(1, "Local", "", inf, inf, inf, inf, inf, inf)
MemberHinge(2, "Local", "", 1000, 2000.0, 3000, 3000, 4000, 5000)
```

Creates hinge params

![image](https://user-images.githubusercontent.com/26790705/192288505-d82c537f-0c30-49cc-9913-326f4978ee7b.png)

So passed values are in [N] not in [kN]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

