### PR TITLE
fix: rows entry for moments

### DIFF
--- a/RFEM/TypesForMembers/memberHinge.py
+++ b/RFEM/TypesForMembers/memberHinge.py
@@ -349,8 +349,8 @@ class MemberHinge():
             for i,j in enumerate(rotational_release_mt_nonlinearity[1][2]):
                 mlvlp = Model.clientModel.factory.create('ns0:member_hinge_diagram_around_x_table_row')
                 mlvlp.no = i+1
-                mlvlp.row.displacement = rotational_release_mt_nonlinearity[1][2][i][0]
-                mlvlp.row.force = rotational_release_mt_nonlinearity[1][2][i][1]
+                mlvlp.row.rotation = rotational_release_mt_nonlinearity[1][2][i][0]
+                mlvlp.row.moment = rotational_release_mt_nonlinearity[1][2][i][1]
                 mlvlp.row.spring = rotational_release_mt_nonlinearity[1][2][i][2]
                 mlvlp.row.note = None
 
@@ -410,8 +410,8 @@ class MemberHinge():
             for i,j in enumerate(rotational_release_my_nonlinearity[1][2]):
                 mlvlp = Model.clientModel.factory.create('ns0:member_hinge_diagram_around_y_table_row')
                 mlvlp.no = i+1
-                mlvlp.row.displacement = rotational_release_my_nonlinearity[1][2][i][0]
-                mlvlp.row.force = rotational_release_my_nonlinearity[1][2][i][1]
+                mlvlp.row.rotation = rotational_release_my_nonlinearity[1][2][i][0]
+                mlvlp.row.moment = rotational_release_my_nonlinearity[1][2][i][1]
                 mlvlp.row.spring = rotational_release_my_nonlinearity[1][2][i][2]
                 mlvlp.row.note = None
 
@@ -469,8 +469,8 @@ class MemberHinge():
             for i,j in enumerate(rotational_release_mz_nonlinearity[1][2]):
                 mlvlp = Model.clientModel.factory.create('ns0:member_hinge_diagram_around_z_table_row')
                 mlvlp.no = i+1
-                mlvlp.row.displacement = rotational_release_mz_nonlinearity[1][2][i][0]
-                mlvlp.row.force = rotational_release_mz_nonlinearity[1][2][i][1]
+                mlvlp.row.rotation = rotational_release_mz_nonlinearity[1][2][i][0]
+                mlvlp.row.moment = rotational_release_mz_nonlinearity[1][2][i][1]
                 mlvlp.row.spring = rotational_release_mz_nonlinearity[1][2][i][2]
                 mlvlp.row.note = None
 


### PR DESCRIPTION
# Description

Row entry for rotations contains **rotation** and **moment** not **displacement** and **force** as right now in python Client.

**Model WS definition - should be**
![rotation moment](https://user-images.githubusercontent.com/26790705/192801572-aeecdbd1-7513-46cb-86e8-410ab96064b9.png)

**python client - is now**
```python
            for i,j in enumerate(rotational_release_mz_nonlinearity[1][2]):
                mlvlp = Model.clientModel.factory.create('ns0:member_hinge_diagram_around_z_table_row')
                mlvlp.no = i+1
                mlvlp.row.displacement = rotational_release_mz_nonlinearity[1][2][i][0]
                mlvlp.row.force = rotational_release_mz_nonlinearity[1][2][i][1]
                mlvlp.row.spring = rotational_release_mz_nonlinearity[1][2][i][2]
                mlvlp.row.note = None

                clientObject.diagram_around_z_table.member_hinge_diagram_around_z_table.append(mlvlp)
```


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
