### PR TITLE
add: setup.py - defualt encoding to utf when reading README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 import pathlib
 
 here = pathlib.Path(__file__).parent
-readme = (here/"README.md").read_text()
+readme = (here/"README.md").read_text(encoding="utf-8")
 
 setup(
     name='RFEM',


### PR DESCRIPTION
# Description

In case when User want to install package from source it is not possible on Windows.
The reason is default Windows encoding https://en.wikipedia.org/wiki/Windows-1252

**To reproduce:**
```bash
git clone https://github.com/Dlubal-Software/RFEM_Python_Client.git
cd RFEM_Python_Client
python .\setup.py install
```
**Output:**
``` bash
> python .\setup.py install
Traceback (most recent call last):
  File "C:\Dev\RFEM_Python_Client\setup.py", line 6, in <module>
    readme = (here/"README.md").read_text()
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python39\lib\pathlib.py", line 1267, in read_text
    return f.read()
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python39\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 4427: character maps to <undefined>
```
Fix:
explicitly set encoding to utf-8 when reading README.md

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

