### PR TITLE
Bug - Member hinge diagram case mz , 2 bug fixes

### DIFF
--- a/RFEM/TypesForMembers/memberHinge.py
+++ b/RFEM/TypesForMembers/memberHinge.py
@@ -400,8 +400,6 @@ class MemberHinge():
                 clientObject.partial_activity_around_y_positive_force = rotational_release_my_nonlinearity[2][1]
                 clientObject.partial_activity_around_y_positive_slippage = rotational_release_my_nonlinearity[2][2]
 
-            clientObject.diagram_around_y_table = Model.clientModel.factory.create('ns0:member_hinge.diagram_around_y_table')
-
         elif rotational_release_my_nonlinearity[0].name == "NONLINEARITY_TYPE_DIAGRAM":
             clientObject.moment_release_my_nonlinearity = rotational_release_my_nonlinearity[0].name
             clientObject.diagram_around_y_start = rotational_release_my_nonlinearity[1][0].name

--- a/RFEM/TypesForMembers/memberHinge.py
+++ b/RFEM/TypesForMembers/memberHinge.py
@@ -462,7 +462,7 @@ class MemberHinge():
                 clientObject.partial_activity_around_z_positive_slippage = rotational_release_mz_nonlinearity[2][2]
 
         elif rotational_release_mz_nonlinearity[0].name == "NONLINEARITY_TYPE_DIAGRAM":
-            clientObject.moment_release_my_nonlinearity = rotational_release_mz_nonlinearity[0].name
+            clientObject.moment_release_mz_nonlinearity = rotational_release_mz_nonlinearity[0].name
             clientObject.diagram_around_z_start = rotational_release_mz_nonlinearity[1][0].name
             clientObject.diagram_around_z_end = rotational_release_mz_nonlinearity[1][1].name
 

--- a/RFEM/TypesForMembers/memberHinge.py
+++ b/RFEM/TypesForMembers/memberHinge.py
@@ -407,6 +407,8 @@ class MemberHinge():
             clientObject.diagram_around_y_start = rotational_release_my_nonlinearity[1][0].name
             clientObject.diagram_around_y_end = rotational_release_my_nonlinearity[1][1].name
 
+            clientObject.diagram_around_y_table = Model.clientModel.factory.create('ns0:member_hinge.diagram_around_y_table')
+
             for i,j in enumerate(rotational_release_my_nonlinearity[1][2]):
                 mlvlp = Model.clientModel.factory.create('ns0:member_hinge_diagram_around_y_table_row')
                 mlvlp.no = i+1
@@ -465,6 +467,8 @@ class MemberHinge():
             clientObject.moment_release_my_nonlinearity = rotational_release_mz_nonlinearity[0].name
             clientObject.diagram_around_z_start = rotational_release_mz_nonlinearity[1][0].name
             clientObject.diagram_around_z_end = rotational_release_mz_nonlinearity[1][1].name
+
+            clientObject.diagram_around_z_table = Model.clientModel.factory.create('ns0:member_hinge.diagram_around_z_table')
 
             for i,j in enumerate(rotational_release_mz_nonlinearity[1][2]):
                 mlvlp = Model.clientModel.factory.create('ns0:member_hinge_diagram_around_z_table_row')


### PR DESCRIPTION
# Description
User cannot create MemberHinge with nonlinearity Diagram type for my, mz. Bugs:

- object creation in wrong place (my), not happens at all (mz)
- wrong name assignment (mz)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?


Bellows code is executable without errors and created wished MemberHinge
```python
    # MemberHingeNonlinearity
    member_hinge_diagram_nonlinearity_1 = [MemberHingeNonlinearity.NONLINEARITY_TYPE_DIAGRAM, [MemberHingeDiagramType.DIAGRAM_ENDING_TYPE_CONTINUOUS, MemberHingeDiagramType.DIAGRAM_ENDING_TYPE_CONTINUOUS, [[0.001, 5280, None], [0.0015, 9240, None], [0.002, 12770, None], [0.0025, 15420, None], [0.003, 17450, None], [0.004, 20480, None], [0.005, 22706, None]]]]
    member_hinge_diagram_nonlinearity_2 = [MemberHingeNonlinearity.NONLINEARITY_TYPE_DIAGRAM, [MemberHingeDiagramType.DIAGRAM_ENDING_TYPE_STOP, MemberHingeDiagramType.DIAGRAM_ENDING_TYPE_STOP, [[0.001, 5280, None], [0.0015, 9240, None], [0.002, 12770, None], [0.0025, 15420, None], [0.003, 17450, None], [0.004, 20480, None], [0.005, 22706, None]]]]
    member_hinge_diagram_nonlinearity_3 = [MemberHingeNonlinearity.NONLINEARITY_TYPE_DIAGRAM, [MemberHingeDiagramType.DIAGRAM_ENDING_TYPE_FAILURE, MemberHingeDiagramType.DIAGRAM_ENDING_TYPE_FAILURE, [[0.001, 5280, None], [0.0015, 9240, None], [0.002, 12770, None], [0.0025, 15420, None], [0.003, 17450, None], [0.004, 20480, None], [0.005, 22706, None]]]]
    member_hinge_diagram_nonlinearity_4 = [MemberHingeNonlinearity.NONLINEARITY_TYPE_DIAGRAM, [MemberHingeDiagramType.DIAGRAM_ENDING_TYPE_YIELDING, MemberHingeDiagramType.DIAGRAM_ENDING_TYPE_YIELDING, [[0.001, 5280, None], [0.0015, 9240, None], [0.002, 12770, None], [0.0025, 15420, None], [0.003, 17450, None], [0.004, 20480, None], [0.005, 22706, None]]]]

    # MemberHinges
    MemberHinge(1, "Local", "", 0, 0, 0, 0, 0, 0, member_hinge_diagram_nonlinearity_1, member_hinge_diagram_nonlinearity_2, member_hinge_diagram_nonlinearity_3, member_hinge_diagram_nonlinearity_4, member_hinge_diagram_nonlinea
   
 ```
 
 
![image](https://user-images.githubusercontent.com/26790705/193017704-fdd2513f-47d5-4dd0-973c-cdeda75ca867.png)


- [ ] Unit Tests
- [x] Attached examples


