### PR TITLE
OndrejMichal: bug 40607

### DIFF
--- a/RFEM/Tools/GetObjectNumbersByType.py
+++ b/RFEM/Tools/GetObjectNumbersByType.py
@@ -21,9 +21,16 @@ class GetObjectNumbersByType:
         ObjectNumber = Model.clientModel.service.get_all_object_numbers_by_type(ObjectType.name)
         ObjectNumberList = []
 
-        if len(ObjectNumber) != 0:
+        if len(ObjectNumber):
             for i in range(len(ObjectNumber.item)):
-                ObjectNumberList.append(ObjectNumber.item[i].no)
-            ObjectNumberList.sort()
+                itemCount = 0
+                # this is used when requesting objects in loads (E_OBJECT_TYPE_NODAL_LOAD, E_OBJECT_TYPE_LINE_LOAD etc.)
+                try:
+                    itemCount = ObjectNumber.item[i].children
+                # all other objects
+                except:
+                    itemCount = ObjectNumber.item[i].no
+                ObjectNumberList.append(itemCount)
 
+        ObjectNumberList.sort()
         return ObjectNumberList


### PR DESCRIPTION
# Description

GetObjectNumbersByType function doesn't return correct list for E_OBJECT_TYPE_LINE_LOAD. This is because the code accesses item.no, but the Line Loads and I assume all other objects listed under Loads are accessed through item.children.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [ ] Unit Tests
- [ ] Attached examples

**Test Configuration**:
* RFEM version: 6.02.0040.48.451988f762d
* Python version: 3.11.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
