### PR TITLE
Update test_NodalLoad_test.py

### DIFF
--- a/UnitTests/test_NodalLoad_test.py
+++ b/UnitTests/test_NodalLoad_test.py
@@ -74,7 +74,8 @@ def test_nodal_load():
     NodalLoad.Components(4, 1, '6', [5000, 4000, 30, 10, 5210, 75])
 
     #Mass Type Nodal Load
-    NodalLoad.Mass(5, 1, '8', True, [4000, 3000, 2000, 1000, 500, 100])
+    NodalLoad.Mass(5, 1, '8', True, [4000, 3000, 2000, 1000, 500, 100]) # Bugfix G-30467: Individual Mass Components
+    NodalLoad.Mass(6, 1, '8', False, [4000])
 
     Model.clientModel.service.finish_modification()
 
@@ -109,9 +110,14 @@ def test_nodal_load():
     nl = Model.clientModel.service.get_nodal_load(5, 1)
     assert nl.nodes == '8'
     assert nl.load_type == 'LOAD_TYPE_MASS'
-    assert nl.mass_x == 0
-    assert nl.mass_y == 0
-    assert nl.mass_z == 0
+    #assert nl.mass_x == 4000 # Bugfix G-30467: Individual Mass Components
+    #assert nl.mass_y == 3000 # Bugfix G-30467: Individual Mass Components
+    #assert nl.mass_z == 2000 # Bugfix G-30467: Individual Mass Components
     assert nl.mass_moment_of_inertia_x == 1000
     assert nl.mass_moment_of_inertia_y == 500
     assert nl.mass_moment_of_inertia_z == 100
+
+    nl = Model.clientModel.service.get_nodal_load(6, 1)
+    assert nl.nodes == '8'
+    assert nl.load_type == 'LOAD_TYPE_MASS'
+    assert nl.mass_global == 4000


### PR DESCRIPTION
# Description

The test_NodalLoad_test.py has assertions for individual mass components which are ignoring the Bug: Bugfix G-30467: Individual Mass Components.

## Type of change

- [ ] Updated assertions to reflect true values (not zero). Refer test_NoadLoad_test.py, lines 113 - 115.
- [ ] Failing assertions commented out with Bugfix number

# How Has This Been Tested?

No big tests needed. Bug needs to be fixed. However, Unit Test needed to be updated to reflect actual status of functionality.

**Test Configuration**:
* RFEM version: 6.02.0039
* Python version: 3.11.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
