### PR TITLE
DynamicLoads-ResponseSpectrum

### DIFF
--- a/RFEM/DynamicLoads/responseSpectrum.py
+++ b/RFEM/DynamicLoads/responseSpectrum.py
@@ -1,0 +1,121 @@
+from RFEM.initModel import Model, clearAttributes
+from RFEM.enums import ResponseSpectrumDefinitionType
+
+class ResponseSpectrum():
+
+    def __init__(self,
+                 no: int = 1,
+                 name: str = '',
+                 constant_period_step: float = None,
+                 sort_table: bool = True,
+                 user_defined_spectrum: list = None,
+                 comment: str = '',
+                 params: dict = None,
+                 model = Model):
+
+        # client model | response spectrum
+        clientObject = model.clientModel.factory.create('ns0:response_spectrum')
+
+        # clear object atributes | sets all the atributes to none
+        clearAttributes(clientObject)
+
+        # response spectrum no.
+        clientObject.no = no
+
+        # response spectrum definition type
+        clientObject.definition_type = ResponseSpectrumDefinitionType.USER_DEFINED.name
+
+        # user defined name
+        if name:
+            clientObject.user_defined_name_enabled = True
+            clientObject.name = name
+
+        # constant period step option
+        if constant_period_step:
+            clientObject.user_defined_response_spectrum_step_enabled = True
+            clientObject.user_defined_response_spectrum_period_step = constant_period_step
+
+        # sort table option
+        clientObject.user_defined_spectrum_sorted = sort_table
+
+        # user defined spectrum
+        clientObject.user_defined_response_spectrum = model.clientModel.factory.create('ns0:response_spectrum.user_defined_response_spectrum')
+
+        for i,j in enumerate(user_defined_spectrum):
+            rsp = model.clientModel.factory.create('ns0:response_spectrum_user_defined_response_spectrum_row')
+            rsp.no = i+1
+            rsp.row.period = user_defined_spectrum[i][0]
+            rsp.row.acceleration = user_defined_spectrum[i][1]
+
+            clientObject.user_defined_response_spectrum.response_spectrum_user_defined_response_spectrum.append(rsp)
+
+        # comment
+        clientObject.comment = comment
+
+        # adding optional parameters via dictionary
+        if params:
+            for key in params:
+                clientObject[key] = params[key]
+
+        # add global parameter to client model
+        model.clientModel.service.set_response_spectrum(clientObject)
+
+
+    @staticmethod
+    def UserDefinedGFactor(no: int = 1,
+                           name: str = '',
+                           constant_period_step: float = None,
+                           sort_table: bool = True,
+                           user_defined_spectrum: list = None,
+                           comment: str = '',
+                           params: dict = None,
+                           model = Model):
+
+        # client model | response spectrum
+        clientObject = model.clientModel.factory.create('ns0:response_spectrum')
+
+        # clear object atributes | sets all the atributes to none
+        clearAttributes(clientObject)
+
+        # response spectrum no.
+        clientObject.no = no
+
+        # response spectrum definition type
+        clientObject.definition_type = ResponseSpectrumDefinitionType.USER_DEFINED_IN_G_FACTOR.name
+
+        # user defined name
+        if name:
+            clientObject.user_defined_name_enabled = True
+            clientObject.name = name
+
+        # constant period step option
+        if constant_period_step:
+            clientObject.user_defined_response_spectrum_step_enabled = True
+            clientObject.user_defined_response_spectrum_period_step = constant_period_step
+
+        # sort table option
+        clientObject.user_defined_spectrum_sorted = sort_table
+
+        # user defined spectrum
+        clientObject.user_defined_response_spectrum = model.clientModel.factory.create('ns0:response_spectrum.user_defined_response_spectrum')
+
+        for i,j in enumerate(user_defined_spectrum):
+            rsp = model.clientModel.factory.create('ns0:response_spectrum_user_defined_response_spectrum_row')
+            rsp.no = i+1
+            rsp.row.period = user_defined_spectrum[i][0]
+            rsp.row.acceleration = user_defined_spectrum[i][1]
+
+            clientObject.user_defined_response_spectrum.response_spectrum_user_defined_response_spectrum.append(rsp)
+
+        # comment
+        clientObject.comment = comment
+
+        # adding optional parameters via dictionary
+        if params:
+            for key in params:
+                clientObject[key] = params[key]
+
+        # add global parameter to client model
+        model.clientModel.service.set_response_spectrum(clientObject)
+
+

--- a/RFEM/enums.py
+++ b/RFEM/enums.py
@@ -2325,3 +2325,9 @@ class FormulaParameter(Enum):
     Formula Parameter to Return from Formula.Get Function
     '''
     ALL, FORMULA, IS_VALID, CALCULATED_VALUE = range(4)
+
+class ResponseSpectrumDefinitionType(Enum):
+    '''
+    Response Spectrum Definition Type
+    '''
+    ACCORDING_TO_STANDARD, GENERATED_FROM_ACCELEROGRAM, USER_DEFINED, USER_DEFINED_IN_G_FACTOR = range(4)

--- a/UnitTests/test_ResponseSpectrum.py
+++ b/UnitTests/test_ResponseSpectrum.py
@@ -1,0 +1,38 @@
+import sys
+import os
+PROJECT_ROOT = os.path.abspath(os.path.join(
+                  os.path.dirname(__file__),
+                  os.pardir)
+)
+sys.path.append(PROJECT_ROOT)
+
+from RFEM.initModel import Model, SetAddonStatus
+from RFEM.enums import AddOn
+from RFEM.DynamicLoads.responseSpectrum import ResponseSpectrum
+
+
+if Model.clientModel is None:
+    Model()
+
+def test_response_spectrum():
+
+    SetAddonStatus(Model.clientModel, AddOn.spectral_active, True)
+    Model.clientModel.service.delete_all()
+    Model.clientModel.service.begin_modification()
+
+    # create user defined response spectrum
+    ResponseSpectrum(2, user_defined_spectrum=[[0, 0.66], [0.15, 1.66]])
+    ResponseSpectrum.UserDefinedGFactor(3, 'secondSpectrum', 0.12, True, [[1, 0.5], [2, 1]])
+    Model.clientModel.service.finish_modification()
+
+    rsp_2 = Model.clientModel.service.get_response_spectrum(2)
+    rsp_3 = Model.clientModel.service.get_response_spectrum(3)
+
+    assert rsp_2.no == 2
+    assert rsp_3.user_defined_response_spectrum_period_step == 0.12
+    assert round(rsp_2.user_defined_response_spectrum[0][0]['row']['acceleration'], 2) == 0.66
+    assert round(rsp_2.user_defined_response_spectrum[0][1]['row']['period'], 2) == 0.15
+
+
+
+


### PR DESCRIPTION
# Description

ResponseSpectrum class under DynamicLoads has created. Accelograms is still missing in the core. Addition to that, there are only user defined options available in the core, response spectrum definition acc. to standards are still not ready.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [x] Unit Tests
- [ ] Attached examples

**Test Configuration**:
* RFEM / RSTAB version: 6.02.0041
* Python version: 3.10


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
