### PR TITLE
Add a parameter for ExportResultTablesToHtml()

### DIFF
--- a/RFEM/Reports/html.py
+++ b/RFEM/Reports/html.py
@@ -202,7 +202,7 @@ def __writeToFile(TargetFilePath, output):
                     line = line[:beginId]+'<sup>'+line[beginId+1:endId]+'</sup>'+line[endId:]
             f.write(line+'\n')
 
-def ExportResultTablesToHtml(TargetFolderPath: str):
+def ExportResultTablesToHtml(TargetFolderPath: str, OpenBrowser: bool = True):
     '''
     This feature allows the user to create an output HTML file with the results.
     The results are in the same form as result tables in RFEM.
@@ -280,5 +280,6 @@ def ExportResultTablesToHtml(TargetFolderPath: str):
         for line in indexOutput:
             f.write(line+'\n')
 
-    # Open result html page
-    os.system(f"start {os.path.join(TargetFolderPath, 'index.html')}")
+    if OpenBrowser:
+        # Open result html page
+        os.system(f"start {os.path.join(TargetFolderPath, 'index.html')}")


### PR DESCRIPTION
# Description


Small improvement that gives the user the choice to open the browser or not after generating the HTML report.
The default is to open the browser. This does not change the behavior of the function in existing program code.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Local test in a example.

- [ ] Unit Tests
- [ ] Attached examples

**Test Configuration**:
* RFEM / RSTAB version: 6.022.0058.61
* Python version: 3.10.8
