### PR TITLE
added missing import to dependencies (psutil)

### DIFF
--- a/RFEM/dependencies.py
+++ b/RFEM/dependencies.py
@@ -15,6 +15,7 @@ try:
     import mock
     import suds.transport
     import suds.client # suds-py3
+    import psutil
 
 except:
     print('One of the required modules is not installed in your Python env.')
@@ -26,10 +27,10 @@ except:
         import subprocess
         try:
             subprocess.call('python -m pip install --upgrade pip')
-            subprocess.call('python -m pip install requests six suds-py3 xmltodict pytest mock --user')
+            subprocess.call('python -m pip install psutil requests six suds-py3 xmltodict pytest mock --user')
         except:
             print('WARNING: Installation of modules failed!')
-            print('Please use command "python -m pip install requests six suds-py3 xmltodict pytest mock --user" in your Command Prompt.')
+            print('Please use command "python -m pip install psutil requests six suds-py3 xmltodict pytest mock --user" in your Command Prompt.')
             input('Press Enter to exit...')
             sys.exit()
     else:


### PR DESCRIPTION
# Description

When I tried to run the pytest Unit tests for the first time, a lot of the tests failed because I didn't have installed _psutil_. Therefore I added it in the dependencies file.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Tests
- [ ] Attached examples

**Test Configuration**:
* RFEM / RSTAB version: 6.04.0002
* Python version: 3.8.10


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
