### PR TITLE
added parameter for unlock stiffness modif of thickness layers

### DIFF
--- a/RFEM/BasicObjects/thickness.py
+++ b/RFEM/BasicObjects/thickness.py
@@ -480,6 +480,7 @@ class Thickness():
         if stiffness_reduction:
             clientObject.stiffness_reduction_enabled = stiffness_reduction
             if stiffness_modification:
+                clientObject.stiffness_reduction_elements_editing_enabled = stiffness_reduction
                 clientObject.K33 = stiffness_modification[0][0]
                 clientObject.K33_note = stiffness_modification[0][1]
                 clientObject.K44 = stiffness_modification[1][0]


### PR DESCRIPTION
# Description

Added paramater **stiffness_reduction_elements_editing_enabled** for unlock user defined stiffness paramaters of thickness with layers - will be available in 6.05.0007

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [ ] Attached examples

**Test Configuration**:
* RFEM / RSTAB version:
* Python version:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
