### PR TITLE
Heet update initModel

### DIFF
--- a/RFEM/initModel.py
+++ b/RFEM/initModel.py
@@ -327,6 +327,7 @@ def openFile(model_path):
     assert os.path.exists(model_path)
 
     file_name = os.path.basename(model_path)
+    connectToServer()
     connectionGlobals.client.service.open_model(model_path)
 
     return Model(False, file_name)
@@ -341,8 +342,11 @@ def closeModel(index_or_name, save_changes = False):
         index_or_name : Model Index or Name to be Close
         save_changes (bool): Enable/Disable Save Changes Option
     '''
+
+    connectToServer()
+
     if isinstance(index_or_name, int):
-        Model.__delete__(Model, index_or_name)
+        # Model.__delete__(Model, index_or_name)
         connectionGlobals.client.service.close_model(index_or_name, save_changes)
 
     elif isinstance(index_or_name, str):
@@ -352,12 +356,12 @@ def closeModel(index_or_name, save_changes = False):
         modelLs = connectionGlobals.client.service.get_model_list().name
         if index_or_name in modelLs:
             try:
-                Model.__delete__(Model, index_or_name)
+                # Model.__delete__(Model, index_or_name)
                 connectionGlobals.client.service.close_model(modelLs.index(index_or_name), save_changes)
             except:
                 print('Model did NOT close properly.')
         else:
-            print('\nINFO: Model "'+modelLs+'" is not opened.')
+            print('\nINFO: Model "'+index_or_name+'" is not opened.')
     else:
         assert False, 'Parameter index_or_name must be int or string.'
 

--- a/RFEM/initModel.py
+++ b/RFEM/initModel.py
@@ -241,7 +241,7 @@ class Model():
         Args:
             index_or_name (str or int): Name of the index of model
         '''
-        if isinstance(index_or_name, str):
+        if isinstance(index_or_name, str) and index_or_name in self.clientModelDct:
             assert index_or_name in list(self.clientModelDct)
             self.clientModelDct.pop(index_or_name)
             if len(self.clientModelDct) > 0:
@@ -252,8 +252,7 @@ class Model():
         if isinstance(index_or_name, int):
             assert index_or_name <= len(self.clientModelDct)
             modelLs = connectionGlobals.client.service.get_model_list()
-
-            if modelLs:
+            if modelLs and (modelLs.name[index_or_name] in self.clientModelDct):
                 self.clientModelDct.pop(modelLs.name[index_or_name])
                 if len(self.clientModelDct) > 0:
                     model_key = list(self.clientModelDct)[-1]
@@ -344,9 +343,8 @@ def closeModel(index_or_name, save_changes = False):
     '''
 
     connectToServer()
-
     if isinstance(index_or_name, int):
-        # Model.__delete__(Model, index_or_name)
+        Model.__delete__(Model, index_or_name)
         connectionGlobals.client.service.close_model(index_or_name, save_changes)
 
     elif isinstance(index_or_name, str):
@@ -356,7 +354,7 @@ def closeModel(index_or_name, save_changes = False):
         modelLs = connectionGlobals.client.service.get_model_list().name
         if index_or_name in modelLs:
             try:
-                # Model.__delete__(Model, index_or_name)
+                Model.__delete__(Model, index_or_name)
                 connectionGlobals.client.service.close_model(modelLs.index(index_or_name), save_changes)
             except:
                 print('Model did NOT close properly.')


### PR DESCRIPTION
# Description

This PR solve the ``closeModel()`` issue when it is called after ``saveFile()`` with new saved model name. I also update ``openFile()`` with ``connectToServer()`` so we don't have to establish connection explicitly in script via ``Model()`` or ``connectToServer()``. 

Test script:

```py
from RFEM.initModel import Model, connectToServer, openFile, saveFile, closeModel

# connectToServer()       # or Model()

openFile(r'C:/Users/RojivadivaH/Desktop/Demo1.rf6')
print('Model 1 opened.')
saveFile(r'C:/Users/RojivadivaH/Desktop/new_Demo1.rf6')
print('Model 1 saved with new name.')
openFile(r'C:/Users/RojivadivaH/Desktop/Demo2.rf6')
print('Model 2 opened.')
saveFile(r'C:/Users/RojivadivaH/Desktop/new_Demo2.rf6')
print('Model 2 saved with new name.')
closeModel(2)
print('New model 2 is closed!')
closeModel(1)
print('New model 1 is closed!')
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [x] Attached examples

**Test Configuration**:
* RFEM / RSTAB version: 6.06.0005
* Python version: Python 3.11


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
