### PR TITLE
extension for remote access to Webservice via Python HLF client

### DIFF
--- a/RFEM/connectionGlobals.py
+++ b/RFEM/connectionGlobals.py
@@ -1,6 +1,10 @@
+
 url = "http://127.0.0.1"
 port = "8081"
 connected = False
+api_key = None
+verify = True # This can be a boolean or a path to a CA bundle file (in case of self-signed certificate it's required)
+
 
 # Is filled in the initModel
 client = None

--- a/RFEM/connectionGlobals.py
+++ b/RFEM/connectionGlobals.py
@@ -5,7 +5,6 @@ connected = False
 api_key = None
 verify = True # This can be a boolean or a path to a CA bundle file (in case of self-signed certificate it's required)
 
-
 # Is filled in the initModel
 client = None
 ca = None

--- a/RFEM/initModel.py
+++ b/RFEM/initModel.py
@@ -2,6 +2,7 @@ import os
 import sys
 import RFEM.dependencies # dependency check ahead of imports
 import socket
+import ssl
 import requests
 import xmltodict
 from urllib import request
@@ -29,10 +30,30 @@ def connectToServer(url=connectionGlobals.url, port=connectionGlobals.port):
     # local machine url format: 'http://127.0.0.1'
     urlAndPort = f'{url}:{port}'
 
-    # Check if port is listening
-    a_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-    location = (url[7:], int(port))
+    # Parse the hostname from the URL
+    if url.startswith('https://'):
+        hostname = url[8:]  # Remove 'https://'
+
+        context = ssl.create_default_context()
+        # context.load_verify_locations(cafile=connectionGlobals.verify)
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        a_socket = context.wrap_socket(sock, server_hostname=hostname)
+        new_wsdl = request.urlopen(urlAndPort+'/wsdl', context=context)
+
+    elif url.startswith('http://'):
+        hostname = url[7:]  # Remove 'http://'
+        a_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        new_wsdl = request.urlopen(urlAndPort+'/wsdl')
+    else:
+        hostname = url
+        a_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        new_wsdl = request.urlopen(urlAndPort+'/wsdl')
+
+    location = (hostname, int(port))
+
+
+    # Check if port is listening
     result_of_check = a_socket.connect_ex(location)
 
     if result_of_check == 0:
@@ -44,9 +65,10 @@ def connectToServer(url=connectionGlobals.url, port=connectionGlobals.port):
         a_socket.close()
         sys.exit()
 
+
     # Delete old cache if the version or mode doesn't correlate
     connectionGlobals.cacheLoc = os.path.join(gettempdir(), 'WSDL')
-    new_wsdl = request.urlopen(urlAndPort+'/wsdl')
+
     new_wsdl_data = new_wsdl.read()
     new_wsdl.close()
     new_tns = xmltodict.parse(new_wsdl_data)['definitions']['@targetNamespace']
@@ -65,10 +87,15 @@ def connectToServer(url=connectionGlobals.url, port=connectionGlobals.port):
     # Check for issues locally and remotely
     try:
         connectionGlobals.ca = DocumentCache(location=connectionGlobals.cacheLoc)
-        connectionGlobals.client = Client(urlAndPort+'/wsdl', location = urlAndPort, cache=connectionGlobals.ca)
+        trans = RequestsTransport(
+            api_key=connectionGlobals.api_key,
+            session=connectionGlobals.session,
+            verify=connectionGlobals.verify
+        )
+        connectionGlobals.client = Client(urlAndPort+'/wsdl', location = urlAndPort, cache=connectionGlobals.ca, transport=trans)
         connectionGlobals.connected = True
 
-    except:
+    except Exception as e:
         print('Error: Connection to server failed!')
         print('Please check:')
         print('- If you have started RFEM application')
@@ -82,7 +109,7 @@ def connectToServer(url=connectionGlobals.url, port=connectionGlobals.port):
 
     try:
         modelLst = connectionGlobals.client.service.get_model_list()
-    except:
+    except Exception as e:
         print('Error: Please check if all RFEM dialogs are closed.')
         input('Press Enter to exit...')
         sys.exit()
@@ -169,7 +196,12 @@ class Model():
                 connectionGlobals.session = requests.Session()
                 adapter = requests.adapters.HTTPAdapter(pool_connections=1, pool_maxsize=1)
                 connectionGlobals.session.mount('http://', adapter)
-                trans = RequestsTransport(connectionGlobals.session)
+                connectionGlobals.session.mount('https://', adapter)
+                trans = RequestsTransport(
+                    api_key=connectionGlobals.api_key,
+                    session = connectionGlobals.session,
+                    verify=connectionGlobals.verify
+                )
 
                 cModel = Client(modelCompletePath, transport=trans, location = modelUrlPort, cache=connectionGlobals.ca, timeout=360)
 
@@ -201,7 +233,12 @@ class Model():
                 connectionGlobals.session = requests.Session()
                 adapter = requests.adapters.HTTPAdapter(pool_connections=1, pool_maxsize=1)
                 connectionGlobals.session.mount('http://', adapter)
-                trans = RequestsTransport(connectionGlobals.session)
+                connectionGlobals.session.mount('https://', adapter)
+                trans = RequestsTransport(
+                    api_key=connectionGlobals.api_key,
+                    session = connectionGlobals.session,
+                    verify=connectionGlobals.verify
+                )
 
                 cModel = Client(modelCompletePath, transport=trans, location = modelUrlPort, cache=connectionGlobals.ca, timeout=360)
             elif model_name == "":
@@ -213,7 +250,12 @@ class Model():
                 connectionGlobals.session = requests.Session()
                 adapter = requests.adapters.HTTPAdapter(pool_connections=1, pool_maxsize=1)
                 connectionGlobals.session.mount('http://', adapter)
-                trans = RequestsTransport(connectionGlobals.session)
+                connectionGlobals.session.mount('https://', adapter)
+                trans = RequestsTransport(
+                    api_key=connectionGlobals.api_key,
+                    session = connectionGlobals.session,
+                    verify=connectionGlobals.verify
+                )
 
                 cModel = Client(modelCompletePath, transport=trans, location = modelUrlPort, cache=connectionGlobals.ca, timeout=360)
             else:

--- a/RFEM/initModel.py
+++ b/RFEM/initModel.py
@@ -30,17 +30,14 @@ def connectToServer(url=connectionGlobals.url, port=connectionGlobals.port):
     # local machine url format: 'http://127.0.0.1'
     urlAndPort = f'{url}:{port}'
 
-
     # Parse the hostname from the URL
     if url.startswith('https://'):
         hostname = url[8:]  # Remove 'https://'
-
         context = ssl.create_default_context()
         # context.load_verify_locations(cafile=connectionGlobals.verify)
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         a_socket = context.wrap_socket(sock, server_hostname=hostname)
         new_wsdl = request.urlopen(urlAndPort+'/wsdl', context=context)
-
     elif url.startswith('http://'):
         hostname = url[7:]  # Remove 'http://'
         a_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -51,7 +48,6 @@ def connectToServer(url=connectionGlobals.url, port=connectionGlobals.port):
         new_wsdl = request.urlopen(urlAndPort+'/wsdl')
 
     location = (hostname, int(port))
-
 
     # Check if port is listening
     result_of_check = a_socket.connect_ex(location)
@@ -64,7 +60,6 @@ def connectToServer(url=connectionGlobals.url, port=connectionGlobals.port):
         print('- If you have started RFEM application at the remote destination correctly.')
         a_socket.close()
         sys.exit()
-
 
     # Delete old cache if the version or mode doesn't correlate
     connectionGlobals.cacheLoc = os.path.join(gettempdir(), 'WSDL')

--- a/RFEM/initModel.py
+++ b/RFEM/initModel.py
@@ -90,7 +90,7 @@ def connectToServer(url=connectionGlobals.url, port=connectionGlobals.port):
         connectionGlobals.client = Client(urlAndPort+'/wsdl', location = urlAndPort, cache=connectionGlobals.ca, transport=trans)
         connectionGlobals.connected = True
 
-    except Exception as e:
+    except Exception:
         print('Error: Connection to server failed!')
         print('Please check:')
         print('- If you have started RFEM application')
@@ -104,7 +104,7 @@ def connectToServer(url=connectionGlobals.url, port=connectionGlobals.port):
 
     try:
         modelLst = connectionGlobals.client.service.get_model_list()
-    except Exception as e:
+    except Exception:
         print('Error: Please check if all RFEM dialogs are closed.')
         input('Press Enter to exit...')
         sys.exit()

--- a/RFEM/initModel.py
+++ b/RFEM/initModel.py
@@ -34,7 +34,8 @@ def connectToServer(url=connectionGlobals.url, port=connectionGlobals.port):
     if url.startswith('https://'):
         hostname = url[8:]  # Remove 'https://'
         context = ssl.create_default_context()
-        # context.load_verify_locations(cafile=connectionGlobals.verify)
+        if isinstance(connectionGlobals.verify, str):
+            context.load_verify_locations(cafile=connectionGlobals.verify)
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         a_socket = context.wrap_socket(sock, server_hostname=hostname)
         new_wsdl = request.urlopen(urlAndPort+'/wsdl', context=context)

--- a/RFEM/suds_requests.py
+++ b/RFEM/suds_requests.py
@@ -21,7 +21,6 @@ import functools
 import requests
 import suds.transport as transport
 import traceback
-import ssl
 from six import BytesIO
 
 def handle_errors(f):

--- a/UnitTests/test_DesignOverview.py
+++ b/UnitTests/test_DesignOverview.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import pytest
 PROJECT_ROOT = os.path.abspath(os.path.join(
                   os.path.dirname(__file__),
                   os.pardir)
@@ -8,6 +9,7 @@ sys.path.append(PROJECT_ROOT)
 
 from RFEM.enums import AddOn
 from RFEM.initModel import Model, SetAddonStatus, getPathToRunningRFEM
+from RFEM.connectionGlobals import url
 from RFEM.Results.designOverview import GetDesignOverview, GetPartialDesignOverview
 from RFEM.Reports.partsList import GetPartsListAllByMaterial, GetPartsListMemberRepresentativesByMaterial
 from RFEM.Reports.partsList import GetPartsListMemberSetsByMaterial, GetPartsListMembersByMaterial
@@ -15,6 +17,10 @@ from RFEM.Reports.partsList import GetPartsListSolidsByMaterial, GetPartsListSur
 
 if Model.clientModel is None:
     Model()
+
+@pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
+                    Althought it is easy to change, it would not be easy to update on every remote computer.\
+                    It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
 
 def test_designOverview():
 

--- a/UnitTests/test_Export.py
+++ b/UnitTests/test_Export.py
@@ -18,6 +18,10 @@ from RFEM import connectionGlobals
 if Model.clientModel is None:
     Model()
 
+@pytest.mark.skipif(connectionGlobals.url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file paths. \
+                    Althought it is easy to change, it would not be easy to update on every remote computer.\
+                    It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
+
 def test_export():
 
     Model.clientModel.service.delete_all()

--- a/UnitTests/test_Export.py
+++ b/UnitTests/test_Export.py
@@ -21,7 +21,6 @@ if Model.clientModel is None:
 @pytest.mark.skipif(connectionGlobals.url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file paths. \
                     Althought it is easy to change, it would not be easy to update on every remote computer.\
                     It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
-
 def test_export():
 
     Model.clientModel.service.delete_all()

--- a/UnitTests/test_GetAllObjects.py
+++ b/UnitTests/test_GetAllObjects.py
@@ -6,10 +6,17 @@ PROJECT_ROOT = os.path.abspath(os.path.join(
 )
 sys.path.append(PROJECT_ROOT)
 from RFEM.initModel import Model, getPathToRunningRFEM
+from RFEM.connectionGlobals import url
 from RFEM.Tools.GetObjectNumbersByType import GetAllObjects
+import pytest
 
 if Model.clientModel is None:
     Model()
+
+
+@pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
+                    Althought it is easy to change, it would not be easy to update on every remote computer.\
+                    It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
 
 def test_GetAllObjects():
 

--- a/UnitTests/test_GetAllObjects.py
+++ b/UnitTests/test_GetAllObjects.py
@@ -13,11 +13,9 @@ import pytest
 if Model.clientModel is None:
     Model()
 
-
 @pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
                     Althought it is easy to change, it would not be easy to update on every remote computer.\
                     It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
-
 def test_GetAllObjects():
 
     Model.clientModel.service.delete_all()

--- a/UnitTests/test_GlobalParameters_Test.py
+++ b/UnitTests/test_GlobalParameters_Test.py
@@ -13,6 +13,8 @@ import pytest
 from RFEM.enums import GlobalParameterUnitGroup, GlobalParameterDefinitionType, ObjectTypes
 from RFEM.globalParameter import GlobalParameter
 from RFEM.initModel import Model, getPathToRunningRFEM
+from RFEM.connectionGlobals import url
+import pytest
 
 if Model.clientModel is None:
     Model()
@@ -78,6 +80,11 @@ def test_global_parameters():
     assert gp_2.max == 100
     assert gp_2.steps == 4
     assert gp_2.unit_group == 'LOADS_DENSITY'
+
+
+@pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
+                    Althought it is easy to change, it would not be easy to update on every remote computer.\
+                    It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
 
 def test_set_and_get_formula():
 

--- a/UnitTests/test_GlobalParameters_Test.py
+++ b/UnitTests/test_GlobalParameters_Test.py
@@ -85,7 +85,6 @@ def test_global_parameters():
 @pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
                     Althought it is easy to change, it would not be easy to update on every remote computer.\
                     It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
-
 def test_set_and_get_formula():
 
     Model.clientModel.service.delete_all()

--- a/UnitTests/test_Reports.py
+++ b/UnitTests/test_Reports.py
@@ -20,6 +20,7 @@ if Model.clientModel is None:
 @pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
                     Althought it is easy to change, it would not be easy to update on every remote computer.\
                     It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
+
 def test_html_report():
     Model.clientModel.service.delete_all()
     Model.clientModel.service.run_script(os.path.join(getPathToRunningRFEM(),'scripts\\internal\\Demos\\Demo-002 Cantilever Beams.js'))
@@ -33,6 +34,11 @@ def test_html_report():
     ExportResultTablesToHtml(folderPath, False)
 
     assert os.path.exists(folderPath)
+
+
+@pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
+                    Althought it is easy to change, it would not be easy to update on every remote computer.\
+                    It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
 
 def test_printout_report():
     # Remove any previous results if they exist

--- a/UnitTests/test_Reports.py
+++ b/UnitTests/test_Reports.py
@@ -16,11 +16,9 @@ import time
 if Model.clientModel is None:
     Model()
 
-
 @pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
                     Althought it is easy to change, it would not be easy to update on every remote computer.\
                     It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
-
 def test_html_report():
     Model.clientModel.service.delete_all()
     Model.clientModel.service.run_script(os.path.join(getPathToRunningRFEM(),'scripts\\internal\\Demos\\Demo-002 Cantilever Beams.js'))
@@ -35,11 +33,9 @@ def test_html_report():
 
     assert os.path.exists(folderPath)
 
-
 @pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
                     Althought it is easy to change, it would not be easy to update on every remote computer.\
                     It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
-
 def test_printout_report():
     # Remove any previous results if they exist
     dirname = os.path.join(os.getcwd(), os.path.dirname(__file__))

--- a/UnitTests/test_ResultTables.py
+++ b/UnitTests/test_ResultTables.py
@@ -9,11 +9,16 @@ PROJECT_ROOT = os.path.abspath(os.path.join(
 )
 sys.path.append(PROJECT_ROOT)
 from RFEM.initModel import Model, getPathToRunningRFEM
+from RFEM.connectionGlobals import url
 from RFEM.enums import CaseObjectType
 from RFEM.Results.resultTables import ResultTables
 
 if Model.clientModel is None:
     Model()
+
+@pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
+                    Althought it is easy to change, it would not be easy to update on every remote computer.\
+                    It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
 
 def test_result_tables():
     Model.clientModel.service.delete_all()

--- a/UnitTests/test_ResultTables.py
+++ b/UnitTests/test_ResultTables.py
@@ -19,7 +19,6 @@ if Model.clientModel is None:
 @pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
                     Althought it is easy to change, it would not be easy to update on every remote computer.\
                     It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
-
 def test_result_tables():
     Model.clientModel.service.delete_all()
     Model.clientModel.service.run_script(os.path.join(getPathToRunningRFEM(),'scripts\\internal\\Demos\\Demo-004 Bus Station-Concrete Design.js'))

--- a/UnitTests/test_SectionDialogue.py
+++ b/UnitTests/test_SectionDialogue.py
@@ -7,12 +7,19 @@ PROJECT_ROOT = os.path.abspath(os.path.join(
 sys.path.append(PROJECT_ROOT)
 
 from RFEM.initModel import Model
+from RFEM.connectionGlobals import url
 from RFEM.Tools.sectionDialogue import *
 from RFEM.BasicObjects.section import Section
 from RFEM.BasicObjects.material import Material
+import pytest
 
 if Model.clientModel is None:
     Model()
+
+
+@pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
+                    Althought it is easy to change, it would not be easy to update on every remote computer.\
+                    It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
 
 def test_section_dialogue():
 

--- a/UnitTests/test_SectionDialogue.py
+++ b/UnitTests/test_SectionDialogue.py
@@ -16,11 +16,9 @@ import pytest
 if Model.clientModel is None:
     Model()
 
-
 @pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
                     Althought it is easy to change, it would not be easy to update on every remote computer.\
                     It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
-
 def test_section_dialogue():
 
     Model.clientModel.service.delete_all()

--- a/UnitTests/test_nodalReleaseType.py
+++ b/UnitTests/test_nodalReleaseType.py
@@ -7,12 +7,18 @@ PROJECT_ROOT = os.path.abspath(os.path.join(
 sys.path.append(PROJECT_ROOT)
 
 from RFEM.initModel import Model, getPathToRunningRFEM
+from RFEM.connectionGlobals import url
 from RFEM.enums import NodalReleaseTypeReleaseNonlinearity, NodalReleaseTypePartialActivityAround, NodalReleaseTypeLocalAxisSystemObjectType
 from RFEM.enums import NodalReleaseTypePartialActivityAlong, NodalReleaseTypeDiagram
 from RFEM.TypesForSpecialObjects.nodalReleaseType import NodalReleaseType
+import pytest
 
 if Model.clientModel is None:
     Model()
+
+@pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
+                    Althought it is easy to change, it would not be easy to update on every remote computer.\
+                    It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
 
 def test_NodalReleaseType():
 

--- a/UnitTests/test_nodalReleaseType.py
+++ b/UnitTests/test_nodalReleaseType.py
@@ -19,7 +19,6 @@ if Model.clientModel is None:
 @pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
                     Althought it is easy to change, it would not be easy to update on every remote computer.\
                     It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
-
 def test_NodalReleaseType():
 
     Model.clientModel.service.delete_all()
@@ -47,7 +46,6 @@ def test_NodalReleaseType():
     assert nrt_1.diagram_around_x_start == "DIAGRAM_ENDING_TYPE_FAILURE"
     assert nrt_1.diagram_around_x_table[0][0].row['rotation'] == 0.01
     assert nrt_1.diagram_around_x_table[0][0].row['moment'] == 1000
-
 
     nrt_2 = Model.clientModel.service.get_nodal_release_type(2)
     assert nrt_2.axial_release_vy_nonlinearity == "NONLINEARITY_TYPE_DIAGRAM"

--- a/UnitTests/test_suds_requests.py
+++ b/UnitTests/test_suds_requests.py
@@ -73,7 +73,11 @@ def test_open():
     assert response.read() == b'abc123'
 
 
-def test_send():
+@pytest.mark.parametrize("url", [
+    "http://url",
+    "https://url"
+])
+def test_send(url):
     session = mock.Mock()
     session.post.return_value.content = b'abc123'
     session.post.return_value.headers = {
@@ -83,7 +87,7 @@ def test_send():
     session.post.return_value.status_code = 200
     transport = suds_requests.RequestsTransport(session)
     request = suds.transport.Request(
-        'http://url',
+        url,
         'I AM SOAP! WHY AM I NOT CLEAN!!!',
     )
     request.headers = {
@@ -94,12 +98,13 @@ def test_send():
     reply = transport.send(request)
 
     session.post.assert_called_with(
-        'http://url',
+        url,
         data='I AM SOAP! WHY AM I NOT CLEAN!!!',
         headers={
             'A': 1,
             'B': 2,
         },
+        verify=True
     )
     assert reply.code == 200
     assert reply.headers == {

--- a/UnitTests/test_timberMoistureClass.py
+++ b/UnitTests/test_timberMoistureClass.py
@@ -8,15 +8,21 @@ sys.path.append(PROJECT_ROOT)
 
 from RFEM.enums import AddOn, TimberMoistureClassType
 from RFEM.initModel import Model, SetAddonStatus, AddOn, openFile, closeModel
+from RFEM.connectionGlobals import url
 from RFEM.BasicObjects.material import Material
 from RFEM.BasicObjects.section import Section
 from RFEM.BasicObjects.node import Node
 from RFEM.BasicObjects.member import Member
 from RFEM.TypesForTimberDesign.timberMoistureClass import TimberMoistureClass
 from RFEM.LoadCasesAndCombinations.loadCasesAndCombinations import LoadCasesAndCombinations
+import pytest
 
 if Model.clientModel is None:
     Model()
+
+@pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
+                    Althought it is easy to change, it would not be easy to update on every remote computer.\
+                    It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
 
 def test_timberMoistureClass():
 

--- a/UnitTests/test_timberServiceConditionCSA.py
+++ b/UnitTests/test_timberServiceConditionCSA.py
@@ -8,15 +8,21 @@ sys.path.append(PROJECT_ROOT)
 
 from RFEM.enums import AddOn, TimberServiceConditionsMoistureType, TimberServiceConditionsTreatmentType
 from RFEM.initModel import Model, SetAddonStatus, AddOn, openFile, closeModel
+from RFEM.connectionGlobals import url
 from RFEM.BasicObjects.material import Material
 from RFEM.BasicObjects.section import Section
 from RFEM.BasicObjects.node import Node
 from RFEM.BasicObjects.member import Member
 from RFEM.TypesForTimberDesign.timberServiceCondition import TimberServiceConditions
 from RFEM.LoadCasesAndCombinations.loadCasesAndCombinations import LoadCasesAndCombinations
+import pytest
 
 if Model.clientModel is None:
     Model()
+
+@pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
+                    Althought it is easy to change, it would not be easy to update on every remote computer.\
+                    It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
 
 def test_timberServiceConditionsCSA():
 

--- a/UnitTests/test_timberServiceConditionCSA.py
+++ b/UnitTests/test_timberServiceConditionCSA.py
@@ -23,7 +23,6 @@ if Model.clientModel is None:
 @pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
                     Althought it is easy to change, it would not be easy to update on every remote computer.\
                     It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
-
 def test_timberServiceConditionsCSA():
 
     dirname = os.path.join(os.getcwd(), os.path.dirname(__file__))

--- a/UnitTests/test_timberServiceConditionGB.py
+++ b/UnitTests/test_timberServiceConditionGB.py
@@ -8,15 +8,21 @@ sys.path.append(PROJECT_ROOT)
 
 from RFEM.enums import AddOn, TimberServiceConditionsMoistureType
 from RFEM.initModel import Model, SetAddonStatus, AddOn, openFile, closeModel
+from RFEM.connectionGlobals import url
 from RFEM.BasicObjects.material import Material
 from RFEM.BasicObjects.section import Section
 from RFEM.BasicObjects.node import Node
 from RFEM.BasicObjects.member import Member
 from RFEM.TypesForTimberDesign.timberServiceCondition import TimberServiceConditions
 from RFEM.LoadCasesAndCombinations.loadCasesAndCombinations import LoadCasesAndCombinations
+import pytest
 
 if Model.clientModel is None:
     Model()
+
+@pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
+                    Althought it is easy to change, it would not be easy to update on every remote computer.\
+                    It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
 
 def test_timberServiceConditionsGB():
 

--- a/UnitTests/test_timberServiceConditionGB.py
+++ b/UnitTests/test_timberServiceConditionGB.py
@@ -23,7 +23,6 @@ if Model.clientModel is None:
 @pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
                     Althought it is easy to change, it would not be easy to update on every remote computer.\
                     It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
-
 def test_timberServiceConditionsGB():
 
     dirname = os.path.join(os.getcwd(), os.path.dirname(__file__))

--- a/UnitTests/test_timberServiceConditionNDS.py
+++ b/UnitTests/test_timberServiceConditionNDS.py
@@ -8,15 +8,21 @@ sys.path.append(PROJECT_ROOT)
 
 from RFEM.enums import AddOn, TimberServiceConditionsMoistureType, TimberServiceConditionsTemperatureType
 from RFEM.initModel import Model, SetAddonStatus, AddOn, openFile, closeModel
+from RFEM.connectionGlobals import url
 from RFEM.BasicObjects.material import Material
 from RFEM.BasicObjects.section import Section
 from RFEM.BasicObjects.node import Node
 from RFEM.BasicObjects.member import Member
 from RFEM.TypesForTimberDesign.timberServiceCondition import TimberServiceConditions
 from RFEM.LoadCasesAndCombinations.loadCasesAndCombinations import LoadCasesAndCombinations
+import pytest
 
 if Model.clientModel is None:
     Model()
+
+@pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
+                    Althought it is easy to change, it would not be easy to update on every remote computer.\
+                    It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
 
 def test_timberServiceConditionsNDS():
 

--- a/UnitTests/test_timberServiceConditionNDS.py
+++ b/UnitTests/test_timberServiceConditionNDS.py
@@ -23,7 +23,6 @@ if Model.clientModel is None:
 @pytest.mark.skipif(url != 'http://127.0.0.1', reason="This test fails on remote PC due to incorrect file path. \
                     Althought it is easy to change, it would not be easy to update on every remote computer.\
                     It is not necessary to evaluate Client as functional. Localy this tests still gets executed.")
-
 def test_timberServiceConditionsNDS():
 
     dirname = os.path.join(os.getcwd(), os.path.dirname(__file__))


### PR DESCRIPTION
# Description

Extension of Python HLF to support remote access to Webservice via network. On the server side it's necessary to run RFEM with allowed SSL connection (installed certificates) and on client side it's necessary to run RFEM Python client with proper settings in connectionGlobals.py (url to remote PC: https://x.x.x.x and api_key from Extranet/MyData). As mandatory condition it's required to have allowed remote access to Webservice for given contact which is used to login to RFEM/RSTAB on server side (it's necessary to contact Dlubal admin for that)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Tests
- [x] Attached examples

**Test Configuration**:
* RFEM version: 6.07.0001
* Python version:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
