### PR TITLE
Bugfix for bug 241711 (TimberServiceClass)

### DIFF
--- a/RFEM/TypesForTimberDesign/timberMoistureClass.py
+++ b/RFEM/TypesForTimberDesign/timberMoistureClass.py
@@ -37,7 +37,7 @@ class TimberMoistureClass():
         clientObject.no = no
 
         # Assigned Members
-        clientObject.member = ConvertToDlString(members)
+        clientObject.members = ConvertToDlString(members)
 
         # Assigned Member Sets
         clientObject.member_sets = ConvertToDlString(member_sets)

--- a/RFEM/TypesForTimberDesign/timberServiceClass.py
+++ b/RFEM/TypesForTimberDesign/timberServiceClass.py
@@ -39,7 +39,7 @@ class TimberServiceClass():
         clientObject.no = no
 
         # Assigned Members
-        clientObject.member = ConvertToDlString(members)
+        clientObject.members = ConvertToDlString(members)
 
         # Assigned Member Sets
         clientObject.member_sets = ConvertToDlString(member_sets)

--- a/RFEM/TypesForTimberDesign/timberServiceCondition.py
+++ b/RFEM/TypesForTimberDesign/timberServiceCondition.py
@@ -53,7 +53,7 @@ class TimberServiceConditions():
         clientObject.no = no
 
         # Assigned Members
-        clientObject.member = ConvertToDlString(members)
+        clientObject.members = ConvertToDlString(members)
 
         # Assigned Member Sets
         clientObject.member_sets = ConvertToDlString(member_sets)

--- a/UnitTests/test_timberMoistureClass.py
+++ b/UnitTests/test_timberMoistureClass.py
@@ -55,7 +55,7 @@ def test_timberMoistureClass():
     Model.clientModel.service.finish_modification()
 
     tmc = Model.clientModel.service.get_timber_moisture_class(1)
-    assert tmc.member == '1'
+    assert tmc.members == '1'
     assert tmc.moisture_class == TimberMoistureClassType.TIMBER_MOISTURE_CLASS_TYPE_2.name
 
     closeModel('timberMoistureClass.rf6')

--- a/UnitTests/test_timberServiceClass.py
+++ b/UnitTests/test_timberServiceClass.py
@@ -38,5 +38,5 @@ def test_timberServiceClass():
 
     tsc = Model.clientModel.service.get_timber_service_class(1)
 
-    assert tsc.member == '1 2'
+    assert tsc.members == '1 2'
     assert tsc.service_class == TimberServiceClassServiceClass.TIMBER_SERVICE_CLASS_TYPE_2.name


### PR DESCRIPTION
# Description

I fixed a bug that occured while trying to create a TimberServiceClass(). There was a typo (member instead of members) in the code of the HLF.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [x] Attached examples
[TimberServiceClass_Test.zip](https://github.com/user-attachments/files/16452560/TimberServiceClass_Test.zip)

**Test Configuration**:
* RFEM version: 6.07.0005
* Python version: 3.10.11


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
