### PR TITLE
Bugfix imports.py -> remove sys.path.clear()

### DIFF
--- a/RFEM/ImportExport/imports.py
+++ b/RFEM/ImportExport/imports.py
@@ -5,7 +5,7 @@ PROJECT_ROOT = os.path.abspath(os.path.join(
                   os.path.dirname(__file__),
                   os.pardir)
 )
-sys.path.clear()
+
 sys.path.append(PROJECT_ROOT)
 from RFEM.initModel import Model
 from RFEM import connectionGlobals


### PR DESCRIPTION
For the love of god why is there sys.path.clear()??? What is going on? When ImportExport is loaded first to your program for any reason, it breaks EVERYTHING. You cannot import anything else because suddenly there is only RFEM as root... Jesus it took me so long to figure out whats going on...

# Description

If import.py is imported first, for any reason, it breaks eveything afterwards...

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

It hasnt because it doesnt change anything

- [ ] Unit Tests
- [ ] Attached examples

**Test Configuration**:
* RFEM version:
* Python version:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
