### PR TITLE
Temporary fix for load combinations

### DIFF
--- a/Examples/SteelDesign/SteelDesignExcel.py
+++ b/Examples/SteelDesign/SteelDesignExcel.py
@@ -141,7 +141,8 @@ def main():
     if lst:
         if 'SteelHallExcel' in lst[0]:
             print('Closing old Model...!')
-            connectionGlobals.client.service.close_model(0, False)
+            index = lst.index('SteelHallExcel')
+            connectionGlobals.client.service.close_model(index, False)
             print('Creating new model...!')
             Model(True, 'SteelHallExcel.rf6', delete_all= True)
 

--- a/Examples/SteelDesign/SteelDesignExcel.py
+++ b/Examples/SteelDesign/SteelDesignExcel.py
@@ -24,6 +24,8 @@ from RFEM.SteelDesign.steelUltimateConfigurations import SteelDesignUltimateConf
 from RFEM.Imperfections.imperfectionCase import ImperfectionCase
 from RFEM.Imperfections.memberImperfection import MemberImperfection
 from RFEM.LoadCasesAndCombinations.loadCasesAndCombinations import LoadCasesAndCombinations
+from RFEM.LoadCasesAndCombinations.designSituation import DesignSituation
+from RFEM.LoadCasesAndCombinations.loadCombination import LoadCombination
 from RFEM.LoadCasesAndCombinations.loadCase import LoadCase
 from RFEM.LoadCasesAndCombinations.staticAnalysisSettings import StaticAnalysisSettings
 from RFEM.Loads.nodalLoad import NodalLoad
@@ -376,6 +378,9 @@ def main():
     LoadCase.StaticAnalysis(4, 'Wind-Load_x', True, 1, ActionCategoryType.ACTION_CATEGORY_WIND_QW, [False])
     LoadCase.StaticAnalysis(5, 'Wind-Load_y', True, 1, ActionCategoryType.ACTION_CATEGORY_WIND_QW, [False])
 
+    DesignSituation(1, DesignSituationType.DESIGN_SITUATION_TYPE_EQU_PERMANENT_AND_TRANSIENT)
+    LoadCombination(1, AnalysisType.ANALYSIS_TYPE_STATIC, 1, '', 1)
+
     # Creating Loads for LC2:Live Load
     n, k, l = 0, 0, 0
     for j in range(frame_number):
@@ -431,7 +436,7 @@ def main():
 
     # Calculation
     print("Calculation started...")
-    Model.clientModel.service.generate_load_cases_and_combinations()
+    #Model.clientModel.service.generate_load_cases_and_combinations()
     Calculate_all()
     print("Done!")
 
@@ -447,7 +452,7 @@ def main():
     nodeSupportForce_x, nodeSupportForce_y, nodeSupportForce_z, nodeMoment_x, nodeMoment_y, nodeMoment_z = [], [], [], [], [], []
 
     for j in range(nodes):
-        dispTab = ResultTables.NodesDeformations(CaseObjectType.E_OBJECT_TYPE_LOAD_COMBINATION, 7, j+1)
+        dispTab = ResultTables.NodesDeformations(CaseObjectType.E_OBJECT_TYPE_LOAD_COMBINATION, 1, j+1)
         nodisp_abs = GetMaxValue(dispTab, 'displacement_absolute') * 1000
         nodisp_x = GetMaxValue(dispTab, 'displacement_x') * 1000
         nodisp_y = GetMaxValue(dispTab, 'displacement_y') * 1000
@@ -467,7 +472,7 @@ def main():
         nodeType = '-'
         if (j+1) in nodes_no:
             nodeType = 'Hinged'
-            supportForceTab = ResultTables.NodesSupportForces(CaseObjectType.E_OBJECT_TYPE_LOAD_COMBINATION, 7, j+1)
+            supportForceTab = ResultTables.NodesSupportForces(CaseObjectType.E_OBJECT_TYPE_LOAD_COMBINATION, 1, j+1)
             nodesupforce_x = GetMaxValue(supportForceTab, 'support_force_p_x')
             nodesupforce_y = GetMaxValue(supportForceTab, 'support_force_p_y')
             nodesupforce_z = GetMaxValue(supportForceTab, 'support_force_p_z')
@@ -508,7 +513,7 @@ def main():
 
     k = 1
     for j in range(beam_column):
-        dispTable = ResultTables.MembersLocalDeformations(CaseObjectType.E_OBJECT_TYPE_LOAD_COMBINATION, 7, object_no=k)
+        dispTable = ResultTables.MembersLocalDeformations(CaseObjectType.E_OBJECT_TYPE_LOAD_COMBINATION, 1, object_no=k)
         maxDisp_abs = GetMaxValue(dispTable, 'displacement_absolute') * 1000
         maxDisp_x = GetMaxValue(dispTable, 'displacement_x') * 1000
         maxDisp_y = GetMaxValue(dispTable, 'displacement_y') * 1000
@@ -518,7 +523,7 @@ def main():
         maxDisplacement_y.append(round(maxDisp_y, 3))
         maxDisplacement_z.append(round(maxDisp_z, 3))
 
-        momentTable = ResultTables.MembersInternalForces(CaseObjectType.E_OBJECT_TYPE_LOAD_COMBINATION, 7, object_no=k)
+        momentTable = ResultTables.MembersInternalForces(CaseObjectType.E_OBJECT_TYPE_LOAD_COMBINATION, 1, object_no=k)
 
         if abs(GetMaxValue(momentTable, 'internal_force_n')) > abs(GetMinValue(momentTable, 'internal_force_n')):
             maxFor_n = GetMaxValue(momentTable, 'internal_force_n') / 1000
@@ -584,7 +589,7 @@ def main():
     maxMoment_my = np.array([maxMoment_my]).T
     maxMoment_mz = np.array([maxMoment_mz]).T
 
-    summary = ResultTables.Summary(CaseObjectType.E_OBJECT_TYPE_LOAD_COMBINATION, 7)
+    summary = ResultTables.Summary(CaseObjectType.E_OBJECT_TYPE_LOAD_COMBINATION, 1)
     df = pd.DataFrame(summary)
     new_df = df.loc[:,['description', 'value', 'units', 'notes']]
 

--- a/Examples/SteelDesign/SteelDesignExcel.py
+++ b/Examples/SteelDesign/SteelDesignExcel.py
@@ -26,6 +26,7 @@ from RFEM.Imperfections.memberImperfection import MemberImperfection
 from RFEM.LoadCasesAndCombinations.loadCasesAndCombinations import LoadCasesAndCombinations
 from RFEM.LoadCasesAndCombinations.designSituation import DesignSituation
 from RFEM.LoadCasesAndCombinations.loadCombination import LoadCombination
+from RFEM.LoadCasesAndCombinations.combinationWizard import CombinationWizard
 from RFEM.LoadCasesAndCombinations.loadCase import LoadCase
 from RFEM.LoadCasesAndCombinations.staticAnalysisSettings import StaticAnalysisSettings
 from RFEM.Loads.nodalLoad import NodalLoad
@@ -141,7 +142,7 @@ def main():
     if lst:
         if 'SteelHallExcel' in lst[0]:
             print('Closing old Model...!')
-            index = lst.index('SteelHallExcel')
+            index = lst[0].index('SteelHallExcel')
             connectionGlobals.client.service.close_model(index, False)
             print('Creating new model...!')
             Model(True, 'SteelHallExcel.rf6', delete_all= True)
@@ -379,8 +380,8 @@ def main():
     LoadCase.StaticAnalysis(4, 'Wind-Load_x', True, 1, ActionCategoryType.ACTION_CATEGORY_WIND_QW, [False])
     LoadCase.StaticAnalysis(5, 'Wind-Load_y', True, 1, ActionCategoryType.ACTION_CATEGORY_WIND_QW, [False])
 
-    DesignSituation(1, DesignSituationType.DESIGN_SITUATION_TYPE_EQU_PERMANENT_AND_TRANSIENT)
-    LoadCombination(1, AnalysisType.ANALYSIS_TYPE_STATIC, 1, '', 1)
+    CombinationWizard(1, consider_imperfection_case=False, params={'structure_modification_enabled':'False'} )
+    DesignSituation(1, DesignSituationType.DESIGN_SITUATION_TYPE_EQU_PERMANENT_AND_TRANSIENT, params={'combination_wizard': 1})
 
     # Creating Loads for LC2:Live Load
     n, k, l = 0, 0, 0
@@ -437,7 +438,7 @@ def main():
 
     # Calculation
     print("Calculation started...")
-    #Model.clientModel.service.generate_load_cases_and_combinations()
+    Model.clientModel.service.generate_load_cases_and_combinations()
     Calculate_all()
     print("Done!")
 


### PR DESCRIPTION
# Description

I fixed the example SteelDesignExcel.py again. Because of a bug in WS core the load combinations are not generated automatically which leads to an error during steel design calculation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [ ] Attached examples

**Test Configuration**:
* RFEM version: 6.08.0007
* Python version: 3.13.0


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
